### PR TITLE
Servir recetas

### DIFF
--- a/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
@@ -145,6 +145,15 @@ public class FarmaciaControlador implements Serializable {
     }
     
     /**
+     * Comprobar si la receta ha sido marcada como servida
+     * @param receta Objeto {@link Receta}
+     * @return True si la receta tiene estado SERVIDA
+     */
+    public boolean isRecetaGenerada(Receta receta) {
+        return receta.getEstado().equals(EstadoReceta.GENERADA);
+    }
+    
+    /**
      * Construye una lista con los posibles estados de una receta.
      * Estos estados serán mostrados en la vista como un elemento
      * de dropdown para poder cambiar el estado de cada receta.
@@ -163,5 +172,4 @@ public class FarmaciaControlador implements Serializable {
     public void onEstadoSeleccionado(Receta recetaConEstado) {
         recetaDAO.actualizar(recetaConEstado);
     }
-    
 }

--- a/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
@@ -170,6 +170,7 @@ public class FarmaciaControlador implements Serializable {
      * @param recetaConEstado Objeto {@link Receta} con el estado actualizado
      */
     public void onEstadoSeleccionado(Receta recetaConEstado) {
+        recetaConEstado.setFarmaciaDispensadora(this.farmaciaActual);
         recetaDAO.actualizar(recetaConEstado);
     }
 }

--- a/src/main/webapp/farmacia/privado/listado_recetas.xhtml
+++ b/src/main/webapp/farmacia/privado/listado_recetas.xhtml
@@ -24,17 +24,19 @@
                             <h:outputText value="#{receta.inicioValidez}"/>
                         </b:dataTableColumn>
                         <b:dataTableColumn label="Fin validez">
-                            <h:outputText value="#{receta.finValidez}"/>
+                            <h:outputText value="#{receta.finValidez}"/>    
                         </b:dataTableColumn>
                         <b:dataTableColumn label="Estado">
                             <b:selectOneMenu 
                                 value="#{receta.estado}" 
                                 colMd="2" 
                                 labelColMd="2" 
-                                rendered="#{farmaciaControlador.isRecetaValida(receta)}" 
+                                rendered="#{farmaciaControlador.isRecetaValida(receta) and farmaciaControlador.isRecetaGenerada(receta)}" 
                                 onchange="ajax:farmaciaControlador.onEstadoSeleccionado(receta)">
                                 <f:selectItems value="#{farmaciaControlador.listEstadoReceta}" var="c" itemValue="#{c}" itemLabel="#{c}"/>
                             </b:selectOneMenu>
+                            
+                            <h:outputText rendered="#{not farmaciaControlador.isRecetaGenerada(receta) or not farmaciaControlador.isRecetaValida(receta)}" value="#{receta.estado}"/>
                         </b:dataTableColumn>
                         <b:dataTableColumn label="Para suministro">
                             <h:outputText value="#{farmaciaControlador.isRecetaValida(receta)? 'Si': 'No'}"/>

--- a/src/main/webapp/farmacia/privado/listado_recetas.xhtml
+++ b/src/main/webapp/farmacia/privado/listado_recetas.xhtml
@@ -3,7 +3,8 @@
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="http://xmlns.jcp.org/jsf/html"
       xmlns:ui="http://xmlns.jcp.org/jsf/facelets"
-      xmlns:b="http://bootsfaces.net/ui">
+      xmlns:b="http://bootsfaces.net/ui"
+      xmlns:f="http://xmlns.jcp.org/jsf/core">
     
     <ui:composition>
         <h:form id="formularioListado" rendered="#{not empty farmaciaControlador.listRecetasPaciente}">  
@@ -26,7 +27,17 @@
                             <h:outputText value="#{receta.finValidez}"/>
                         </b:dataTableColumn>
                         <b:dataTableColumn label="Estado">
-                            <h:outputText value="#{receta.estado}"/>
+                            <b:selectOneMenu 
+                                value="#{receta.estado}" 
+                                colMd="2" 
+                                labelColMd="2" 
+                                rendered="#{farmaciaControlador.isRecetaValida(receta)}" 
+                                onchange="ajax:farmaciaControlador.onEstadoSeleccionado(receta)">
+                                <f:selectItems value="#{farmaciaControlador.listEstadoReceta}" var="c" itemValue="#{c}" itemLabel="#{c}"/>
+                            </b:selectOneMenu>
+                        </b:dataTableColumn>
+                        <b:dataTableColumn label="Para suministro">
+                            <h:outputText value="#{farmaciaControlador.isRecetaValida(receta)? 'Si': 'No'}"/>
                         </b:dataTableColumn>
                     </b:dataTable>
                 </b:panel>


### PR DESCRIPTION
## Close #2: Servir recetas de paciente
Sólo se pueden servir aquellas recetas que estén disponibles para suministro (sus fechas sean válidas) y cuyo estado sea `GENERADA`. Para controlar dichas restricciones, en la vista se hace uso de los métodos `isRecetaValida()` y `isRecetaGenerada()`, y así mostrar el elemento de la vista correcto. En caso de poder cambiar el estado de la receta, es un menú desplegable con la lista de estados, y sino sólo se muestra el estado actual de la receta.
Importante destacar que una vez la receta ha sido marcada como `SERVIDA`, se le asocia el identificador de la farmacia que la ha servido.

## Resultado
![image](https://user-images.githubusercontent.com/579796/33784464-444b5b98-dc61-11e7-9947-25210f06363f.png)
