### PR TITLE
Cambiar estado de una cita

### DIFF
--- a/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
@@ -193,9 +193,7 @@ public class MedicoControlador implements Serializable {
      */
     private void crearListaEstadosCita() {
         listEstadoCita = new ArrayList<>();
-        listEstadoCita.add(EstadoCita.ANULADA);
         listEstadoCita.add(EstadoCita.AUSENTE);
         listEstadoCita.add(EstadoCita.COMPLETADA);
-        listEstadoCita.add(EstadoCita.PLANIFICADA);
     }
 }

--- a/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
@@ -12,6 +12,7 @@ import es.uvigo.esei.dagss.dominio.entidades.Cita;
 import es.uvigo.esei.dagss.dominio.entidades.Medico;
 import es.uvigo.esei.dagss.dominio.entidades.TipoUsuario;
 import es.uvigo.esei.dagss.dominio.entidades.EstadoCita;
+import es.uvigo.esei.dagss.dominio.entidades.Receta;
 import javax.inject.Named;
 import javax.enterprise.context.SessionScoped;
 import java.io.Serializable;
@@ -36,6 +37,7 @@ public class MedicoControlador implements Serializable {
     private String numeroColegiado;
     private String password;
     private List<Cita> listCitasMedico;
+    private List<EstadoCita> listEstadoCita;
     private Cita citaActual;
 
     @Inject
@@ -98,6 +100,10 @@ public class MedicoControlador implements Serializable {
 
     public void setMedicoActual(Medico medicoActual) {
         this.medicoActual = medicoActual;
+    }
+
+    public List<EstadoCita> getListEstadoCita() {
+        return listEstadoCita;
     }
 
     private boolean parametrosAccesoInvalidos() {
@@ -165,7 +171,20 @@ public class MedicoControlador implements Serializable {
      */
     public String dolistarCitasMedico() {
         this.listCitasMedico = medicoDAO.buscarCitasPorMedico(medicoActual);
+        crearListaEstadosCita();
         return "/medico/privado/agenda/listadoCitas";   
     }
-    
+        
+    /**
+     * Construye una lista con los posibles estados de una cita.
+     * Estos estados serán mostrados en la vista como un elemento
+     * de dropdown para poder cambiar el estado de cada cita.
+     */
+    private void crearListaEstadosCita() {
+        listEstadoCita = new ArrayList<>();
+        listEstadoCita.add(EstadoCita.ANULADA);
+        listEstadoCita.add(EstadoCita.AUSENTE);
+        listEstadoCita.add(EstadoCita.COMPLETADA);
+        listEstadoCita.add(EstadoCita.PLANIFICADA);
+    }
 }

--- a/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/medico/MedicoControlador.java
@@ -51,6 +51,9 @@ public class MedicoControlador implements Serializable {
     
     @EJB
     private MedicoDAO medicoDAO;
+    
+    @EJB
+    private CitaDAO citaDAO;
 
     /**
      * Creates a new instance of AdministradorControlador
@@ -173,6 +176,14 @@ public class MedicoControlador implements Serializable {
         this.listCitasMedico = medicoDAO.buscarCitasPorMedico(medicoActual);
         crearListaEstadosCita();
         return "/medico/privado/agenda/listadoCitas";   
+    }
+    
+    /**
+     * L istener para actualizar el estado de una cita
+     * @param citaConEstado Objeto {@link Cita} con el estado actualizado
+     */
+    public void onEstadoSeleccionado(Cita citaConEstado) {
+        citaDAO.actualizar(citaConEstado);
     }
         
     /**

--- a/src/main/webapp/farmacia/privado/listado_recetas.xhtml
+++ b/src/main/webapp/farmacia/privado/listado_recetas.xhtml
@@ -32,7 +32,8 @@
                                 colMd="2" 
                                 labelColMd="2" 
                                 rendered="#{farmaciaControlador.isRecetaValida(receta) and farmaciaControlador.isRecetaGenerada(receta)}" 
-                                onchange="ajax:farmaciaControlador.onEstadoSeleccionado(receta)">
+                                onchange="ajax:farmaciaControlador.onEstadoSeleccionado(receta)"
+                                update="@(.tablaListadoClass)">
                                 <f:selectItems value="#{farmaciaControlador.listEstadoReceta}" var="c" itemValue="#{c}" itemLabel="#{c}"/>
                             </b:selectOneMenu>
                             

--- a/src/main/webapp/medico/privado/agenda/listadoCitas.xhtml
+++ b/src/main/webapp/medico/privado/agenda/listadoCitas.xhtml
@@ -51,9 +51,14 @@
                             <b:dataTableColumn label="Duración" orderable="false">
                                 <h:outputText value="#{cita.duracion} "/>
                             </b:dataTableColumn>
-
                             <b:dataTableColumn label="Estado">
-                                <h:outputText value="#{cita.estado} "/>
+                                <b:selectOneMenu 
+                                    value="#{cita.estado}" 
+                                    colMd="2" 
+                                    labelColMd="2" 
+                                    onchange="ajax:medicoControlador.onEstadoSeleccionado(cita)">
+                                    <f:selectItems value="#{medicoControlador.listEstadoCita}" var="c" itemValue="#{c}" itemLabel="#{c}"/>
+                                </b:selectOneMenu>
                             </b:dataTableColumn>
 
                             <b:dataTableColumn label="" orderable="false">

--- a/src/main/webapp/medico/privado/agenda/listadoCitas.xhtml
+++ b/src/main/webapp/medico/privado/agenda/listadoCitas.xhtml
@@ -56,7 +56,8 @@
                                     value="#{cita.estado}" 
                                     colMd="2" 
                                     labelColMd="2" 
-                                    onchange="ajax:medicoControlador.onEstadoSeleccionado(cita)">
+                                    onchange="ajax:medicoControlador.onEstadoSeleccionado(cita);"
+                                    update="@(.tablaListadoClass)">
                                     <f:selectItems value="#{medicoControlador.listEstadoCita}" var="c" itemValue="#{c}" itemLabel="#{c}"/>
                                 </b:selectOneMenu>
                             </b:dataTableColumn>


### PR DESCRIPTION
## Close #14: Cambiar estado de una cita
Se ha implementado un menú desplegable `SelectOneMenu` para cambiar el estado de una cita desde el propio listado de citas disponibles, en la agenda actual del médico.
Importante destacar que una vez seleccionado un estado, la tabla se refresca para cambiar las opciones de la cita gracias al siguiente campo en la etiqueta xhtml del archivo JSF:
```java
update="@(.tablaListadoClass)"
```
## Resultado
![image](https://user-images.githubusercontent.com/579796/34454716-6b90e814-ed71-11e7-9c88-ae9150d9d97e.png)

## To test
Es necesario insertar una cita con la fecha actual en la base de datos para que aparezca en la agenda del médico
