### PR TITLE
Planificador de recetas

### DIFF
--- a/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
+++ b/src/main/java/es/uvigo/esei/dagss/controladores/farmacia/FarmaciaControlador.java
@@ -141,7 +141,9 @@ public class FarmaciaControlador implements Serializable {
      * @return True si la receta es válida
      */
     public boolean isRecetaValida(Receta receta) {
-        return receta.getFinValidez().after(new Date());
+        Date today = new Date();
+        return receta.getFinValidez().after(today) &&
+                receta.getInicioValidez().before(today);
     }
     
     /**

--- a/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetas.java
+++ b/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetas.java
@@ -1,0 +1,21 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package es.uvigo.esei.dagss.servicios.prescripcion;
+
+import es.uvigo.esei.dagss.dominio.entidades.Prescripcion;
+import es.uvigo.esei.dagss.dominio.entidades.Receta;
+import java.util.List;
+
+
+public interface PlanificadorRecetas {
+
+    /**
+     * Planificar recetas en funcion a una prescripcion
+     * @param prescripcion Objeto {@link Prescripcion}
+     * @return Lista de objetos {@link Receta}
+     */
+    List<Receta> planificar(Prescripcion prescripcion);
+}

--- a/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetasSemanal.java
+++ b/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetasSemanal.java
@@ -1,0 +1,89 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package es.uvigo.esei.dagss.servicios.prescripcion;
+
+import es.uvigo.esei.dagss.dominio.entidades.EstadoReceta;
+import es.uvigo.esei.dagss.dominio.entidades.Prescripcion;
+import es.uvigo.esei.dagss.dominio.entidades.Receta;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.List;
+import javax.ejb.Stateless;
+
+@Stateless
+public class PlanificadorRecetasSemanal {
+    
+    private final int TIEMPO_CALCULO = 7;
+
+    public List<Receta> planificar(Prescripcion prescripcion) {
+        List<Receta> recipes = new ArrayList<>();
+        
+        // Calcular el rango de días entre dos fechas
+        int totalDias = getTotalDias(
+                prescripcion.getFechaInicio(),
+                prescripcion.getFechaFin());
+        
+        // Calcular el número de días que dura una caja de medicamento
+        int totalDiasPorCaja = 
+                (int) Math.ceil(prescripcion.getMedicamento().getNumeroDosis()/prescripcion.getDosis());
+        
+        // Calcular el numero total de recetas
+        int totalRecetas = (int) Math.ceil((double)totalDias/totalDiasPorCaja);
+        
+        Date inicioValidez = prescripcion.getFechaInicio();
+        Date finValidez = calcularFecha(TIEMPO_CALCULO + totalDiasPorCaja, inicioValidez);
+        
+        for (int i=0; i<totalRecetas; i++) {
+            recipes.add(
+                    new Receta(
+                            prescripcion,           // prescripcion
+                            1,                      // cantidad
+                            inicioValidez,          // fecha de inicio de validez
+                            finValidez,             // fecha de fin de validez
+                            EstadoReceta.GENERADA));// estado GENERADA por defecto
+            
+            inicioValidez = calcularFecha(-TIEMPO_CALCULO - totalDiasPorCaja, finValidez);
+            finValidez = calcularFecha(TIEMPO_CALCULO, finValidez);
+        }
+        
+        return recipes;
+    }
+    
+    /**
+     * Obtener el numero dedias entre dos fechas
+     * @param inicio Fecha inicial
+     * @param fin Fecha final
+     * @return Numero de dias entre la fecha inicial y la fecha final
+     */
+    private int getTotalDias(Date inicio, Date fin) {
+        if (inicio.after(fin)) {
+            throw new IllegalArgumentException("End date should be grater or equals to start date");
+        }
+
+        long inicioDateTime = inicio.getTime();
+        long finDateTime = fin.getTime();
+        long milPerDay = 1000*60*60*24; 
+
+        // sumar uno para incluir el dia actual
+        return (int) ((finDateTime - inicioDateTime) / milPerDay) + 1;
+    }
+    
+    /**
+     * Decrementa o incrementa un numero de dias determinado a una fecha
+     * @param dias Numero de dias a incrementar/decrementar
+     * @param date Fecha de partida
+     * @return Fecha de partida con un incremento/decremeto definido por "dias"
+     */
+    private Date calcularFecha(int dias, Date date) {
+        Calendar calendar = GregorianCalendar.getInstance();
+        calendar.setTime(date);
+        calendar.add(GregorianCalendar.DAY_OF_YEAR, dias);
+        return calendar.getTime();
+    }
+        
+}

--- a/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetasSemanal.java
+++ b/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PlanificadorRecetasSemanal.java
@@ -16,10 +16,11 @@ import java.util.List;
 import javax.ejb.Stateless;
 
 @Stateless
-public class PlanificadorRecetasSemanal {
+public class PlanificadorRecetasSemanal implements PlanificadorRecetas{
     
     private final int TIEMPO_CALCULO = 7;
 
+    @Override
     public List<Receta> planificar(Prescripcion prescripcion) {
         List<Receta> recipes = new ArrayList<>();
         

--- a/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PrescripcionServicio.java
+++ b/src/main/java/es/uvigo/esei/dagss/servicios/prescripcion/PrescripcionServicio.java
@@ -1,0 +1,38 @@
+package es.uvigo.esei.dagss.servicios.prescripcion;
+
+import es.uvigo.esei.dagss.dominio.daos.RecetaDAO;
+import es.uvigo.esei.dagss.dominio.entidades.Prescripcion;
+import es.uvigo.esei.dagss.dominio.entidades.Receta;
+import java.util.List;
+import javax.ejb.Stateless;
+import javax.inject.Inject;
+
+@Stateless
+public class PrescripcionServicio {
+    
+    public static final int PLANIFICADOR_SEMANAL = 0;
+    
+    private PlanificadorRecetas planificadorRecetas;
+    
+    @Inject
+    private RecetaDAO recetaDAO;
+
+    public PrescripcionServicio() {
+    }
+        
+    public void crearPlanificador(int tipoPlanificador) {
+        if(tipoPlanificador==PLANIFICADOR_SEMANAL) {
+            planificadorRecetas = new PlanificadorRecetasSemanal();
+        } else {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+    }
+    
+    public void planificar(Prescripcion prescripcion) {
+        List<Receta> listaRecetas = planificadorRecetas.planificar(prescripcion);
+        for (Receta r: listaRecetas) {
+            recetaDAO.crear(r);
+        }
+    }
+    
+}


### PR DESCRIPTION
## Close #16: Crear plan de recetas
Cuando se crea una prescripción es necesario crear un plan de recetas. 
Para facilitar futuros añadidos  se ha utilizado un patrón [Strategy](https://www.tutorialspoint.com/design_pattern/strategy_pattern.htm) que nos permitirá crear nuevas formas de planificación sin modificar el código actual.
La clase `PrescripcionServicio` también sirve de [Facade](https://www.tutorialspoint.com/design_pattern/facade_pattern.htm) para facilitar la planificación de la prescripción desde el controlador de prescripciones.

Para planificar el reparto de recetas se ha creado un algoritmo basado en lo siguiente:
Una vez generada la prescripción, se leen las fechas de inicio y fin, y la dosis diaria. Según esos valores, se calcula el número de días totales que debe tomarse el medicamento y el número de dosis por cada caja de medicamento. Teniendo estos dos datos, y partiendo de que con una receta sólo se puede obtener una caja, tenemos el número de recetas necesarias para cubrir el período de tratamiento.
En la incidencia #16 se especifica que
> La base para el cálculo de las fechas de validez de las “recetas programadas” será semanal

Y esto se ha interpretado como que, una vez elegidas las fechas exactas de ingesta del medicamento, se establece una semana de margen en el inicio y el final de la validez de la receta.

## Extra
En el commit [05ed4b2](https://github.com/dagss2017/DAGSS2017_beta/commit/05ed4b2d5bd25cbb8e48739dbf3c738d7d3b7f0c) se comprueba que la fecha de inicio y fin de validez de la receta es válido, ya que previamente sólo se comprobaba que la fecha actual no era superior al final de la validez.

